### PR TITLE
tests: Fix format specifier for size_t variable in test_read_file

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -241,7 +241,7 @@ size_t test_read_file(const char *filename, char **buffer, size_t size)
 	if (size > 0) {
 		/* User provided the buffer; make sure it is large enough. */
 		if (size < file_size) {
-			MSG_ERROR("Buffer is small (required %u)\n", file_size);
+			MSG_ERROR("Buffer is small (required %zu)\n", file_size);
 			file_size = 0; /* Unable to read. */
 
 			goto out;
@@ -259,7 +259,7 @@ size_t test_read_file(const char *filename, char **buffer, size_t size)
 		}
 	}
 
-	MSG_INFO("Reading %s, %u Bytes.\n", filename, file_size);
+	MSG_INFO("Reading %s, %zu Bytes.\n", filename, file_size);
 
 	if (fread(file_buf, 1, file_size, file) != file_size) {
 		MSG_ERROR("%s\n", feof(file) ? "EOF" : strerror(errno));


### PR DESCRIPTION
The format specifier %u expects an unsigned int argument, but file_size is declared as size_t. On 64-bit architectures, size_t is 64 bits wide while unsigned int is 32 bits, so using %u can silently truncate large file sizes when printing diagnostic messages.

This mismatch also triggers -Wformat compiler warnings, which become hard build failures when -Werror is enabled. The issue affects two diagnostic messages in test_read_file: one reporting an undersized user-provided buffer, and one logging the number of bytes being read from a file.

Replace %u with %zu, the correct and portable format specifier for size_t as mandated by the C99 standard. This fixes the truncation risk and resolves the -Wformat warning on both 32-bit and 64-bit target architectures with no change in functional behavior.