### PR TITLE
libqcomtee: Restrict object-id space to 32-bits

### DIFF
--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -207,8 +207,8 @@ struct qcomtee_object_ops {
  */
 struct qcomtee_object {
 	atomic_int refs; /**< Number of references to this object. */
-	uint64_t object_id; /**< ID assigned to this object. */
-	uint64_t tee_object_id; /**< ID assigned to this object for QTEE. */
+	uint32_t object_id; /**< ID assigned to this object. */
+	uint32_t tee_object_id; /**< ID assigned to this object for QTEE. */
 	qcomtee_object_type_t object_type; /**< Object Type. */
 
 	/**

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -199,7 +199,7 @@ struct qcomtee_object *qcomtee_object_root_init(const char *dev,
 
 	/* INIT the root object. */
 	QCOMTEE_OBJECT_INIT(&root_object->object, QCOMTEE_OBJECT_TYPE_ROOT);
-	root_object->object.tee_object_id = TEE_OBJREF_NULL;
+	root_object->object.tee_object_id = (uint32_t)TEE_OBJREF_NULL;
 	root_object->object.ops = &qcomtee_object_root_ops;
 	root_object->object.root = &root_object->object;
 	root_object->tee_call = tee_call;


### PR DESCRIPTION
Restrict the object-id space for user-space invoked objects to 32-bits. This allows the QCOMTEE driver to infer whether the object is being invoked from the kernel-space or user-space. The kernel-space dictates a as 64-bit object-id field whose MSB is set when the object is invoked by a kernel client. By restricting the user-space to a 32-bit field, we ensure that the MSB is always unset.
This is also in-line with QTEE expectation of 32-bit object ids.