### PR TITLE
build: fix pkg-config output and USE_QCBOR definition

### DIFF
--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(QCBOR_DIR_HINT "" CACHE PATH "Hint path for QCBOR directory")
 
-find_package(QCBOR REQUIRED)
+find_package(QCBOR)
 if(NOT QCBOR_FOUND)
 	message(WARNING "QCBOR not found, falling back to libcbor")
 endif()

--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -29,7 +29,12 @@ add_library(qcomtee ${SRC})
 
 # ''Library pkg-config file and version''.
 
-set(pc_req_private qcbor)
+if(QCBOR_FOUND)
+	set(pc_req_private qcbor)
+else()
+	set(pc_req_private libcbor)
+endif()
+
 set(libqcomteetgt qcomtee)
 
 configure_file(qcomtee.pc.in qcomtee.pc @ONLY)

--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -11,10 +11,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(QCBOR_DIR_HINT "" CACHE PATH "Hint path for QCBOR directory")
 
 find_package(QCBOR REQUIRED)
-if(QCBOR_FOUND)
-	add_compile_definitions(${PROJECT_NAME}
-		PRIVATE -DUSE_QCBOR)
-else()
+if(NOT QCBOR_FOUND)
 	message(WARNING "QCBOR not found, falling back to libcbor")
 endif()
 
@@ -50,6 +47,7 @@ target_include_directories(qcomtee
 )
 
 if(QCBOR_FOUND)
+	target_compile_definitions(qcomtee PRIVATE USE_QCBOR)
 	target_link_libraries(qcomtee PRIVATE ${QCBOR_LIBRARIES})
 else()
 	target_link_libraries(qcomtee PRIVATE cbor)

--- a/libqcomtee/qcomtee.pc.in
+++ b/libqcomtee/qcomtee.pc.in
@@ -1,7 +1,7 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
+includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@


### PR DESCRIPTION
Follow-up to #23. Four build fixes, two files, no functional change to the library.

### 1. `qcomtee.pc` points at the wrong libdir

`qcomtee.pc.in` hardcodes `libdir="${prefix}/lib"`, but the library installs to
`${CMAKE_INSTALL_LIBDIR}`. Where that resolves to `lib64`, as on Fedora and
openSUSE, consumers get a `-L` path that does not contain `libqcomtee.so`. Now
expands `CMAKE_INSTALL_FULL_LIBDIR` and `CMAKE_INSTALL_FULL_INCLUDEDIR`.

### 2. `USE_QCBOR` is set with the wrong command

`add_compile_definitions()` takes no target and no scope keyword, so

```cmake
add_compile_definitions(${PROJECT_NAME} PRIVATE -DUSE_QCBOR)
```

defines three macros for the whole directory instead of one:

```
-Dlibqcomtee -DPRIVATE -DUSE_QCBOR
```

Switched to `target_compile_definitions()` on the qcomtee target.

### 3. `Requires.private` ignores the libcbor fallback

#23 made the CBOR backend selectable, but `pc_req_private` stayed hardcoded to
`qcbor`. A libcbor build installs a `.pc` declaring a private dependency on a
module that is not present, which breaks static linking and downstream
dependency generation. Now follows `QCBOR_FOUND`. The pkg-config module for
libcbor is named `libcbor`, not `cbor`.

### 4. `find_package(QCBOR REQUIRED)`

QCBOR is optional since #23, so `REQUIRED` states the opposite of the intent. It
is inert only because `cmake/FindQCBOR.cmake` sets `QCBOR_FOUND` by hand and
never calls `find_package_handle_standard_args()`. Happy to drop this commit if
you would rather keep `REQUIRED` for now.

### Testing

Configured both backends with `-DCMAKE_INSTALL_LIBDIR=lib64`:

```
# libcbor fallback
libdir="/usr/lib64"
Requires.private: libcbor

# QCBOR present
libdir="/usr/lib64"
Requires.private: qcbor
```

### Not addressed

`Requires: @pc_req_public@` expands empty since `pc_req_public` is never set.
Harmless, left alone to keep this minimal.